### PR TITLE
Add environment.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *__pycache__*
 export/*
 preprocessed/*
+dataset/*

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 data:
-  data_location: /slow-2/georges/dataset-urmp-wav
+  data_location: ./dataset/
   extension: "wav"
 
 preprocess:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: ddsp-pytorch
+channels:
+  - defaults
+dependencies:
+  - python==3.7
+  - torchvision
+  - cudatoolkit=11.1
+  - torchaudio
+  - pytorch
+  - pyyaml
+  - librosa
+  - crepe
+  - tqdm
+  - tensorflow
+  - tensorboard=1.15
+  - einops
+prefix: /homes/cdl01/.conda/envs/ddsp-pytorch
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,7 @@
 name: ddsp-pytorch
 channels:
+  - conda-forge
+  - anaconda
   - defaults
 dependencies:
   - python==3.7


### PR DESCRIPTION
Added my environment.yml, for a repeatable virtual environment. Only included explicit installs.
Command used to generate it was: `conda env export --from-history > environment.yml`
Channels apart from default added manually.
